### PR TITLE
Updates to baseline fiscal parameters

### DIFF
--- a/examples/run_og_eth.py
+++ b/examples/run_og_eth.py
@@ -70,28 +70,6 @@ def main():
     runner(p, time_path=True, client=client)
     print("run time = ", time.time() - start_time)
 
-    # base_ss = safe_read_pickle(os.path.join(base_dir, "SS", "SS_vars.pkl"))
-    # print("SS tax to GDP ratio: ", base_ss["total_tax_revenue"] / base_ss["Y"])
-
-    # Plot D/Y ratio over time
-    base_tpi = safe_read_pickle(os.path.join(base_dir, "TPI", "TPI_vars.pkl"))
-    plt.plot(base_tpi["D"][:40] / base_tpi["Y"][:40])
-    plt.title("Debt to GDP Ratio Over Time")
-    plt.xlabel("Time Periods")
-    plt.ylabel("D/Y")
-    plt.savefig(os.path.join(save_dir, "debt_to_gdp_ratio.png"))
-
-    # plot tax revenue to gdp and government spending to gdp
-    plt.figure()
-    plt.plot(base_tpi["total_tax_revenue"][:40] / base_tpi["Y"][:40], label="Tax Revenue to GDP")
-    plt.plot((base_tpi["G"][:40] + base_tpi["TR"][:40]) / base_tpi["Y"][:40], label="Government Spending to GDP")
-    plt.title("Government Finance Ratios Over Time")
-    plt.xlabel("Time Periods")
-    plt.ylabel("Ratio")
-    plt.savefig(os.path.join(save_dir, "outlays_rev_to_gdp_ratio.png"))
-
-    quit()
-
     """
     Run reform policy
     ---------------------------------------------------------------------------

--- a/examples/run_og_eth.py
+++ b/examples/run_og_eth.py
@@ -70,8 +70,29 @@ def main():
     runner(p, time_path=True, client=client)
     print("run time = ", time.time() - start_time)
 
+    # base_ss = safe_read_pickle(os.path.join(base_dir, "SS", "SS_vars.pkl"))
+    # print("SS tax to GDP ratio: ", base_ss["total_tax_revenue"] / base_ss["Y"])
+
+    # Plot D/Y ratio over time
+    base_tpi = safe_read_pickle(os.path.join(base_dir, "TPI", "TPI_vars.pkl"))
+    plt.plot(base_tpi["D"][:40] / base_tpi["Y"][:40])
+    plt.title("Debt to GDP Ratio Over Time")
+    plt.xlabel("Time Periods")
+    plt.ylabel("D/Y")
+    plt.savefig(os.path.join(save_dir, "debt_to_gdp_ratio.png"))
+
+    # plot tax revenue to gdp and government spending to gdp
+    plt.figure()
+    plt.plot(base_tpi["total_tax_revenue"][:40] / base_tpi["Y"][:40], label="Tax Revenue to GDP")
+    plt.plot((base_tpi["G"][:40] + base_tpi["TR"][:40]) / base_tpi["Y"][:40], label="Government Spending to GDP")
+    plt.title("Government Finance Ratios Over Time")
+    plt.xlabel("Time Periods")
+    plt.ylabel("Ratio")
+    plt.savefig(os.path.join(save_dir, "outlays_rev_to_gdp_ratio.png"))
+
+    quit()
+
     """
-    ---------------------------------------------------------------------------
     Run reform policy
     ---------------------------------------------------------------------------
     """

--- a/ogeth/constants.py
+++ b/ogeth/constants.py
@@ -400,6 +400,6 @@ PROD_DICT = {
         "amach",
         "aoman",
         "awatr",
-        "acons"
+        "acons",
     ],
 }

--- a/ogeth/constants.py
+++ b/ogeth/constants.py
@@ -299,7 +299,6 @@ Create dictionaries to map micro categories to broad groups
 """
 CONS_DICT = {
     "Food": [
-        "cceri",
         "cmaiz",
         "crice",
         "cocer",
@@ -372,6 +371,7 @@ PROD_DICT = {
         "aoliv",
         "afore",
         "afish",
+        "amine",
     ],
     "Energy": [
         "aelec",
@@ -390,8 +390,16 @@ PROD_DICT = {
         "aosrv",
     ],
     "Secondary Ex Energy": [
-        "amine",
+        "afood",
+        "abeve",
+        "atext",
+        "awood",
+        "achem",
+        "anmet",
+        "ametl",
+        "amach",
+        "aoman",
         "awatr",
-        "acons",
+        "acons"
     ],
 }

--- a/ogeth/macro_params.py
+++ b/ogeth/macro_params.py
@@ -152,7 +152,7 @@ def get_macro_params(
         # source: IMF GFS (12.0.0), indicator G271_T, Budgetary central government
         # source link: https://data.imf.org/en/Data-Explorer?datasetUrn=IMF.STA:GFS_SOO(12.0.0)&INDICATOR=G271_T
         # 2023 = 3.38% of GDP
-        macro_parameters["alpha_T"] = [0.034]
+        macro_parameters["alpha_T"] = [0.034 + 0.016]  # including social benefits of 1.6% of GDP
 
         # alpha_G, total government expenditure as a fraction of GDP
         # source: IMF WEO (9.0.0), indicator GGX, General government expenditure (% of GDP)
@@ -181,7 +181,7 @@ def get_macro_params(
         macro_parameters["zeta_D"] = [0.12]
 
         """"
-        Esimate the discount on sovereign yields relative to private debt
+        Estimate the discount on sovereign yields relative to private debt
         Follow the methodology in Li, Magud, Werner, Witte (2021)
         available at:
         https://www.imf.org/en/Publications/WP/Issues/2021/06/04/The-Long-Run-Impact-of-Sovereign-Yields-on-Corporate-Yields-in-Emerging-Markets-50224

--- a/ogeth/macro_params.py
+++ b/ogeth/macro_params.py
@@ -152,7 +152,9 @@ def get_macro_params(
         # source: IMF GFS (12.0.0), indicator G271_T, Budgetary central government
         # source link: https://data.imf.org/en/Data-Explorer?datasetUrn=IMF.STA:GFS_SOO(12.0.0)&INDICATOR=G271_T
         # 2023 = 3.38% of GDP
-        macro_parameters["alpha_T"] = [0.034 + 0.016]  # including social benefits of 1.6% of GDP
+        macro_parameters["alpha_T"] = [
+            0.034 + 0.016
+        ]  # including social benefits of 1.6% of GDP
 
         # alpha_G, total government expenditure as a fraction of GDP
         # source: IMF WEO (9.0.0), indicator GGX, General government expenditure (% of GDP)

--- a/ogeth/ogeth_default_parameters.json
+++ b/ogeth/ogeth_default_parameters.json
@@ -1177,20 +1177,20 @@
         0.040000000000000036,
         0.040000000000000036
     ],
-    "initial_foreign_debt_ratio": 0.95,
+    "initial_foreign_debt_ratio": 0.42,
     "zeta_D": [
-        0.95
+        0.12
     ],
     "zeta_K": [
-        0.95
+        0.65
     ],
     "tG1": 20,
     "tG2": 256,
     "alpha_T": [
-        0.3
+        0.05
     ],
     "alpha_G": [
-        0.24100000000000002
+        0.095
     ],
     "alpha_I": [
         0.0
@@ -1211,7 +1211,7 @@
         0.0
     ],
     "debt_ratio_ss": 0.6,
-    "initial_debt_ratio": 0.314,
+    "initial_debt_ratio": 0.327,
     "initial_Kg_ratio": 0.0,
     "r_gov_scale": [
         0.24484763593657818
@@ -1226,7 +1226,7 @@
     ],
     "c_corp_share_of_assets": 0.55,
     "adjustment_factor_for_cit_receipts": [
-        0.30909090909090914
+        0.2
     ],
     "inv_tax_credit": [
         [
@@ -1235,7 +1235,7 @@
     ],
     "tau_c": [
         [
-            0.18
+            0.07
         ]
     ],
     "delta_tau_annual": [
@@ -103759,21 +103759,21 @@
     "etr_params": [
         [
             [
-                0.25
+                0.03
             ]
         ]
     ],
     "mtrx_params": [
         [
             [
-                0.25
+                0.2
             ]
         ]
     ],
     "mtry_params": [
         [
             [
-                0.25
+                0.2
             ]
         ]
     ],


### PR DESCRIPTION
This PR fixes the baseline spending parameters to include pension outlays and also updates the tax rates to represent effective tax rates.

Revenue and spending:
<img width="640" height="480" alt="outlays_rev_to_gdp_ratio" src="https://github.com/user-attachments/assets/06761b08-a1ff-45c4-a3e6-87f32898ac37" />


Debt path:
<img width="640" height="480" alt="outlays_rev_to_gdp_ratio" src="https://github.com/user-attachments/assets/08e65476-5e50-4a4f-984e-8f7a4ed7c4af" />


cc @rickecon 