### PR TITLE
Have CI lint use the conda env's black, not psf/black@stable

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -6,9 +6,21 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
-      - uses: psf/black@stable
+      - name: Checkout
+        uses: actions/checkout@v5
         with:
-          options: "-l 79 --check"
-          src: "."
+          persist-credentials: false
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniconda-version: "latest"
+          auto-update-conda: true
+          activate-environment: ogeth-dev
+          environment-file: environment.yml
+          auto-activate-base: false
+
+      - name: Check formatting with black
+        shell: bash -l {0}
+        run: |
+          python -m black --check -l 79 .


### PR DESCRIPTION
Closes #26.

Changes `.github/workflows/check_format.yml` to set up the `ogeth-dev` conda env (same approach as `build_and_test.yml`) and run `python -m black --check -l 79 .` from inside it. Local and CI now resolve black from the same source (conda-forge) instead of two different channels (conda-forge locally, PyPI in CI).

No changes to `environment.yml` or `pyproject.toml`.