### PR TITLE
Fix call to `income.get_e_interp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.7] - 2026-05-12 00:50:00
+
+### Fiex
+
+- Fixed bug in `calibrate.py` where the `income.get_e_interp` function was not being called with the correct parameters. This was causing an error when running the `calibrate.py` script.
+
 ## [0.0.6] - 2026-04-15 15:50:00
 
 ### Added
@@ -62,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This version is a pre-release alpha. The example run script OG-ETH/examples/run_og_eth.py runs, but the model is not currently calibrated to represent the Ethiopian economy and population.
 
 
+[0.0.7]: https://github.com/EAPD-DRB/OG-ETH/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/EAPD-DRB/OG-ETH/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/EAPD-DRB/OG-ETH/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/EAPD-DRB/OG-ETH/compare/v0.0.3...v0.0.4

--- a/ogeth/__init__.py
+++ b/ogeth/__init__.py
@@ -8,4 +8,4 @@ from ogeth.input_output import *
 from ogeth.macro_params import *
 from ogeth.utils import *
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"

--- a/ogeth/calibrate.py
+++ b/ogeth/calibrate.py
@@ -107,10 +107,11 @@ class Calibration:
 
             # earnings profiles
             self.e = income.get_e_interp(
+                p.E,
                 p.S,
-                self.demographic_params["omega_SS"],
-                demog80["omega_SS"],
+                p.J,
                 p.lambdas,
+                demog80["omega_SS"],
                 plot_path=output_path,
             )
         except Exception as exc:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setuptools.setup(
     name="ogeth",
-    version="0.0.6",
+    version="0.0.7",
     author="Marcelo LaFleur, Richard W. Evans, and Jason DeBacker",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="Ethiopia Calibration for OG-Core",


### PR DESCRIPTION
The calibration module was breaking with the call to update the ability profiles because the arguments passed were not correct.  This PR fixes that bug.