### PR TITLE
Read packaged SAM, compute alpha_c from household columns, add import-smoke CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,3 +61,32 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
+  pip-import-smoke:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package and pytest
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install . pytest
+
+      - name: Run import smoke tests outside checkout
+        shell: bash
+        run: |
+          tmpdir="$(mktemp -d)"
+          cp "${{ github.workspace }}/tests/test_import_smoke.py" "$tmpdir/test_import_smoke.py"
+          cd "$tmpdir"
+          python -m pytest "$tmpdir/test_import_smoke.py"

--- a/ogeth/__init__.py
+++ b/ogeth/__init__.py
@@ -8,4 +8,4 @@ from ogeth.input_output import *
 from ogeth.macro_params import *
 from ogeth.utils import *
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"

--- a/ogeth/input_output.py
+++ b/ogeth/input_output.py
@@ -59,13 +59,24 @@ def get_alpha_c(sam=None, cons_dict=CONS_DICT):
         sam = read_SAM()
     if sam is None:
         raise RuntimeError("SAM data is unavailable. Cannot compute alpha_c.")
+
+    hh_cols = [
+        "hhd-r1",
+        "hhd-r2",
+        "hhd-r3",
+        "hhd-r4",
+        "hhd-r5",
+        "hhd-u1",
+        "hhd-u2",
+        "hhd-u3",
+        "hhd-u4",
+        "hhd-u5",
+    ]
     alpha_c = {}
     overall_sum = 0
     for key, value in cons_dict.items():
-        # note the subtraction of the row to focus on domestic consumption
         category_total = (
-            sam.loc[sam.index.isin(value), "total"].sum()
-            - sam.loc[sam.index.isin(value), "row"].sum()
+            sam.loc[sam.index.isin(value), hh_cols].values.astype(float).sum()
         )
         alpha_c[key] = category_total
         overall_sum += category_total

--- a/ogeth/input_output.py
+++ b/ogeth/input_output.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import numpy as np
 import os
-from ogeth.utils import is_connected
 from ogeth.constants import CONS_DICT, PROD_DICT
 
 
@@ -10,52 +9,38 @@ def norm(x):
 
 
 CUR_DIR = os.path.dirname(os.path.realpath(__file__))
-"""
-Read in Social Accounting Matrix (SAM) file
-"""
-# Read in SAM file
-# SAM file:
-# Read in SAM file
-SAM_path = os.path.join(
-    "https://raw.githubusercontent.com/EAPD-DRB/OG-ETH/refs/heads/main/ogeth/data/IFPRI_SAM_ETH_2022_SAM.csv"
-)
+sam_path = os.path.join(CUR_DIR, "data", "IFPRI_SAM_ETH_2022_SAM.csv")
 
 
 def read_SAM():
-    if is_connected():
-        try:
-            SAM = pd.read_csv(
-                SAM_path,
-                index_col=1,
-                thousands=",",
-            ).dropna(how="all")
+    """
+    Read the packaged Ethiopia SAM file.
 
-            print("Successfully read SAM from Github repository.")
+    Returns:
+        pd.DataFrame | None: parsed SAM table, or None if unavailable
+    """
+    try:
+        sam = pd.read_csv(
+            sam_path,
+            index_col=1,
+            thousands=",",
+        ).dropna(how="all")
 
-            # First column is descriptive text, not SAM values
-            label_col = SAM.columns[0]
-            value_cols = SAM.columns.drop(label_col)
+        # First column is descriptive text, not SAM values
+        label_col = sam.columns[0]
+        value_cols = sam.columns.drop(label_col)
 
-            # Convert only SAM value columns to numeric
-            SAM[value_cols] = (
-                SAM[value_cols]
-                .apply(lambda s: pd.to_numeric(s, errors="coerce"))
-                .fillna(0)
-            )
+        # Convert only SAM value columns to numeric
+        sam[value_cols] = (
+            sam[value_cols]
+            .apply(lambda s: pd.to_numeric(s, errors="coerce"))
+            .fillna(0)
+        )
 
-            print(
-                f"{SAM.shape[0]} rows and {SAM.shape[1]} columns in the SAM."
-            )
-        except Exception as e:
-            print(f"Failed to read from the GitHub repository: {e}")
-            SAM = None
-        # If both attempts fail, SAM will be None
-        if SAM is None:
-            print("Failed to read SAM from both sources.")
-    else:  # pragma: no cover
-        SAM = None
-        print("No internet connection. SAM cannot be read.")
-    return SAM
+        return sam
+    except Exception as exc:
+        print(f"Failed to read packaged SAM file: {exc}")
+        return None
 
 
 def get_alpha_c(sam=None, cons_dict=CONS_DICT):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setuptools.setup(
     name="ogeth",
-    version="0.0.7",
+    version="0.0.8",
     author="Marcelo LaFleur, Richard W. Evans, and Jason DeBacker",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="Ethiopia Calibration for OG-Core",

--- a/tests/test_import_smoke.py
+++ b/tests/test_import_smoke.py
@@ -1,0 +1,13 @@
+"""
+Import smoke tests for installed package usage.
+"""
+
+
+def test_import_smoke():
+    import ogeth
+    from ogeth import macro_params
+    from ogeth.calibrate import Calibration
+
+    assert ogeth is not None
+    assert macro_params is not None
+    assert Calibration is not None

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -1,0 +1,73 @@
+"""
+Tests of input_output.py module
+"""
+
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from ogeth import input_output as io
+
+HH_COLS = [
+    "hhd-r1",
+    "hhd-r2",
+    "hhd-r3",
+    "hhd-r4",
+    "hhd-r5",
+    "hhd-u1",
+    "hhd-u2",
+    "hhd-u3",
+    "hhd-u4",
+    "hhd-u5",
+]
+
+
+@pytest.fixture
+def sam_df():
+    data = {col: [0.0, 0.0] for col in HH_COLS}
+    data["hhd-r1"] = [10.0, 30.0]
+    data["hhd-u1"] = [20.0, 40.0]
+    data["A"] = [2.0, 1.0]
+    data["B"] = [1.0, 3.0]
+    return pd.DataFrame(data, index=["beer", "car"])
+
+
+def test_get_alpha_c(sam_df):
+    cons_dict = {"Food": ["beer"], "Non-food": ["car"]}
+
+    test_dict = io.get_alpha_c(sam=sam_df, cons_dict=cons_dict)
+
+    assert isinstance(test_dict, dict)
+    assert sorted(test_dict.keys()) == sorted(["Food", "Non-food"])
+    assert test_dict["Food"] == pytest.approx(0.3)
+    assert test_dict["Non-food"] == pytest.approx(0.7)
+
+
+def test_get_io_matrix(sam_df):
+    cons_dict = {"Food": ["beer"], "Non-food": ["car"]}
+    prod_dict = {"Primary": ["A"], "Secondary": ["B"]}
+
+    test_df = io.get_io_matrix(
+        sam=sam_df, cons_dict=cons_dict, prod_dict=prod_dict
+    )
+
+    assert isinstance(test_df, pd.DataFrame)
+    assert sorted(test_df.columns) == sorted(["Primary", "Secondary"])
+    assert sorted(test_df.index) == sorted(["Food", "Non-food"])
+    assert test_df.loc["Food", "Primary"] == pytest.approx(2 / 3)
+    assert test_df.loc["Food", "Secondary"] == pytest.approx(1 / 3)
+    assert test_df.loc["Non-food", "Primary"] == pytest.approx(1 / 4)
+    assert test_df.loc["Non-food", "Secondary"] == pytest.approx(3 / 4)
+
+
+@patch("ogeth.input_output.read_SAM", return_value=None)
+def test_get_alpha_c_raises_on_none_sam(mock_read_sam):
+    with pytest.raises(RuntimeError, match="Cannot compute alpha_c"):
+        io.get_alpha_c()
+
+
+@patch("ogeth.input_output.read_SAM", return_value=None)
+def test_get_io_matrix_raises_on_none_sam(mock_read_sam):
+    with pytest.raises(RuntimeError, match="Cannot compute io_matrix"):
+        io.get_io_matrix()


### PR DESCRIPTION
This PR:
* Reads the SAM file from `ogeth/data/` instead of fetching it from GitHub at runtime, so offline runs work
* Fixes `alpha_c` to sum only the ten household columns of the SAM (instead of `total - row`, which included government, investment, and intermediate use), matching OG-IDN and OG-PHL
* Adds a `pip-import-smoke` CI job that installs the package and imports it from a temp directory, catching packaging issues invisible from the source tree