### PR TITLE
Floor jupyter-book to 1.x to keep the 3.13 docs build off 0.6.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Defer jupyter-book 2.x (a mystmd rewrite that breaks the current docs build)
+    # until the docs are migrated. The <2.0 ceiling in pyproject already blocks it;
+    # this stops Dependabot from re-opening the major-bump PR each week.
+    ignore:
+      - dependency-name: "jupyter-book"
+        update-types: ["version-update:semver-major"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dev = [
     "jupyter",
 ]
 docs = [
-    "jupyter-book<2.0.0",
+    "jupyter-book>=1.0,<2.0",
     "sphinx>=3.5.4",
     "sphinx-book-theme>=0.1.3",
     "sphinx-argparse",

--- a/uv.lock
+++ b/uv.lock
@@ -1943,7 +1943,7 @@ requires-dist = [
     { name = "ipykernel", marker = "extra == 'dev'" },
     { name = "ipython", marker = "extra == 'dev'" },
     { name = "jupyter", marker = "extra == 'dev'" },
-    { name = "jupyter-book", marker = "extra == 'docs'", specifier = "<2.0.0" },
+    { name = "jupyter-book", marker = "extra == 'docs'", specifier = ">=1.0,<2.0" },
     { name = "linearmodels" },
     { name = "linecheck" },
     { name = "matplotlib" },


### PR DESCRIPTION
Preventive hardening — the same fix as EAPD-DRB/OG-PHL#66 (and OG-ZAF), applied here before it bites.

**The latent bug.** The `docs` extra constrains `jupyter-book` with only a ceiling (`<2.0.0`), no floor. On Python 3.13 — where the docs build runs — the resolver can fall all the way to the ancient **0.6.5**, whose CLI lacks the `clean` command the Makefile calls (`jupyter-book clean docs/book`). That's exactly what broke the docs build on OG-PHL and OG-ZAF. This repo currently locks `1.0.4.post1`, so the build works today, but it's one re-resolve away from the same break.

**The fix.** Add the floor — `jupyter-book>=1.0,<2.0` — and regenerate the lock (it stays at `1.0.4.post1`). I also added a Dependabot `ignore` for jupyter-book's major version so it stops re-proposing the breaking 2.x jump; the ceiling already blocks it, this just quiets the noise. The version policy stays in `pyproject.toml`, and the lock stays Dependabot-managed.

Moving to jupyter-book 2.x is a separate, deliberate piece of work (a mystmd rewrite needing a `myst.yml`, a new Makefile target, and a directive pass); this keeps us pinned to a working 1.x until we choose to do that.

**Verified on Python 3.13.** The docs build succeeds both before and after (`build succeeded`, HTML generated) and jupyter-book stays at `1.0.4.post1`; the lock change is just the constraint, scoped to the docs deps — `ogcore`/`numpy`/`pandas` untouched.

cc @rickecon @jdebacker
